### PR TITLE
Fix invalid JSON in config schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -44,7 +44,7 @@
           "default": "000000",
           "required":true,
           "description": "Serialnumber of stove"
-      },
+      }
     }
   }
 }


### PR DESCRIPTION
We are currently overriding your config schema from our plugins site. However an error is still generated when installing.

This pull request removes the extra comma in your config schema.

You can test your config schemas here
https://mkellsy.github.io/schema/